### PR TITLE
5067574710 js loading speed

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -45,20 +45,24 @@ var LOADING_ROUNDED_OUTLINE = fs.readFileSync(__dirname + '/ui/svg/loading-round
   , LOADING_SHARP_OUTLINE = fs.readFileSync(__dirname + '/ui/svg/loading-sharp-outline.svg');
 
 flowplayer(function(api, root) {
-  common.find('.fp-filters').forEach(common.removeNode);
-  try {
-    var fc;
-    document.body.appendChild(fc = common.createElement('div', {}, fs.readFileSync(__dirname + '/ui/svg/filters.svg')));
-    common.css(fc, {
-      width: 0,
-      height: 0,
-      overflow: 'hidden',
-      position: 'absolute',
-      margin: 0,
-      padding: 0
-    });
+   // This should only be done once, previously it was done for each player, adding about 5 ms for 10 players
+   if( !flowplayer.added_svg_filters ) {
+      flowplayer.added_svg_filters = true;
 
-  } catch (e) { /* omit */ }
+      try {
+         var fc;
+         document.body.appendChild(fc = common.createElement('div', {}, fs.readFileSync(__dirname + '/ui/svg/filters.svg')));
+         common.css(fc, {
+            width: 0,
+            height: 0,
+            overflow: 'hidden',
+            position: 'absolute',
+            margin: 0,
+            padding: 0
+         });
+
+      } catch (e) { /* omit */ }
+   }
 
    var conf = api.conf,
       support = flowplayer.support,

--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -70,7 +70,9 @@ flowplayer(function(api, root) {
    common.find('.fp-ratio,.fp-ui', root).forEach(common.removeNode);
    common.addClass(root, 'flowplayer');
    root.appendChild(common.createElement('div', {className: 'fp-ratio'}));
-   var ui = common.createElement('div', {className: 'fp-ui'}, '\
+
+   // Initially the .fp-ui element is hidden, we show it with requestAnimationFrame later on to optimize modern browser loading
+   var ui = common.createElement('div', {className: 'fp-ui', style: 'display: none'}, '\
          <div class="fp-waiting">\
            {{ LOADING_SHARP_OUTLINE }}\
            {{ LOADING_SHARP_FILL }}\
@@ -128,6 +130,16 @@ flowplayer(function(api, root) {
                 .replace(/url\(#/g, 'url(' + window.location.href.replace(window.location.hash, "").replace(/\#$/g, '') + '#')
    );
    root.appendChild(ui);
+
+   if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame( function() {
+         ui.style.display = '';
+      });
+
+   } else {
+      ui.style.display = '';
+   }
+
    function find(klass) {
      return common.find(".fp-" + klass, root)[0];
    }


### PR DESCRIPTION
Only add SVG filters once.

Add player UI silently (display: none) and then show it all at once using requestAnimationFrame.

This prevents too much redraw when loading.